### PR TITLE
Update theme repo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -117,7 +117,7 @@ pagination_dir: page
 # Extensions
 ## Plugins: https://hexo.io/plugins/
 ## Themes: https://hexo.io/themes/
-theme: jpaztech
+theme: jpazure
 
 feed:
   type: atom


### PR DESCRIPTION
Fix #3  (https://github.com/jpazureid/hexo-theme-jpazure/pull/23 が反映され修正)

jpazure リポジトリで等幅フォントの対応が完了したため、jpaztech のリポジトリから切り替えます。
https://github.com/jpazureid/hexo-theme-jpazure