### PR TITLE
Fix typo in AKS OOMKill article

### DIFF
--- a/articles/containers/aks-oom-202312.md
+++ b/articles/containers/aks-oom-202312.md
@@ -53,7 +53,7 @@ Pod内のコンテナーが確保・利用可能なメモリの上限は、Pod�
 
 Podがノードにスケジュールされる際、ノードが提供可能なメモリが
 Pod・コンテナーに対して十分か否かの判定は、`spec.containers[].resources.limits.memory`
-(制限)ではなく、`spec.containers[].resources.limits.memory`(要求)に基づいて
+(制限)ではなく、`spec.containers[].resources.requests.memory`(要求)に基づいて
 行われます。このため、あるノード上にスケジュールされたPod・コンテナーの
 制限値の合計が、実際にそのノード上で利用可能なメモリ量よりはるかに多い、ということが
 起こり得ます。


### PR DESCRIPTION
This fixes typo in AKS OOMKIll article (2024/12), which says request parametes can be defined
as spec.containers[].resource.limits.memory by mistake, and should be corrected to
spec.containers[].resource.requests.memory.